### PR TITLE
Break SDK and CLI into separate pages

### DIFF
--- a/docs/cli-overview.html
+++ b/docs/cli-overview.html
@@ -1,0 +1,139 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8" />
+    <meta name="keywords" content="Shade, Hue, CLI, Terminal, Command" />
+    <meta name="robots" content="index, follow" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+    <title>CLI / Shade</title>
+
+    <link rel="stylesheet" href="css/reset.css" type="text/css" media="all" />
+    <link href="https://fonts.googleapis.com/css?family=Alegreya+Sans+SC:300|Open+Sans:300|Inconsolata" rel="stylesheet">
+    <link rel="stylesheet" href="css/atom-one-light.css" type="text/css" />
+    <link rel="stylesheet" href="css/atom-one-dark.css" type="text/css" media="(prefers-color-scheme:dark)" />
+    <link rel="stylesheet" href="css/main-1.1.css" type="text/css" media="all" />
+    <link rel="stylesheet" href="css/dark-1.1.css" type="text/css" media="(prefers-color-scheme:dark)" />
+
+    <script src="js/highlight.pack.js"></script>
+    <script>hljs.initHighlightingOnLoad();</script>
+</head>
+<body>
+<header>
+    <a href="index.html">
+        <img src="svg/logo-full-dark.svg" class="logo only-dark" alt="Shade Logo" />
+        <img src="svg/logo-full.svg" class="logo only-light" alt="Shade Logo" />
+    </a>
+</header>
+<section>
+    <header>
+        <a name="cli" href="#cli">
+            <h1>CLI</h1>
+        </a>
+    </header>
+    <p>
+        Shade's CLI can provide an API for system tools to control lights,
+        can be run manually, and functions as a sample project for the SDK!
+    </p>
+    <article>
+        <a href="#cli-install" name="cli-install">
+            <h2>Install</h2>
+        </a>
+        <h3>Using HomeBrew</h3>
+        <p>
+            If you're on a Mac with <a href="https://brew.sh">HomeBrew</a> you can
+            install Shade with the following command:
+        </p>
+        <pre><code class="shell">
+$ brew install inkapplications/cli-tools/shade
+            </code></pre>
+        <h3>Manual Install</h3>
+        <p>
+            For Windows or Linux, Shade's CLI can be installed by
+            downloading the
+            <a href="https://github.com/InkApplications/Shade/releases/latest">latest release</a>
+            and running the or <code>bin/shade.bat</code> or
+            <code>bin/shade</code> executable or adding them to your
+            <code>$PATH</code>.
+        </p>
+    </article>
+    <article>
+        <a href="#cli-connect" name="cli-connect">
+            <h2>Connect to a Hue bridge</h2>
+        </a>
+        <p>
+            You can set up your connection to Hue using the
+            <code>connect</code> command. This will automatically discover
+            hue bridges on the network and attempt to authenticate with
+            them.
+        </p>
+        <pre><code class="shell">
+$ shade connect
+Connecting to bridge at 192.168.1.100
+Waiting to connect. Press the button on your Hue Device now.
+            </code></pre>
+    </article>
+    <article>
+        <a href="#cli-lights-list" name="cli-lights-list">
+            <h2>List lights</h2>
+        </a>
+        <p>
+            You can get information about of all the lights known to your
+            Hue bridge with the <code>lights:list</code> command.
+        </p>
+        <pre><code class="shell">
+$ shade lights:list
+1:
+  name: Renee's Office
+  uuid: 00:19:28:37:00:a1:b9:f2-0b
+  type: Extended color light
+  firmware: 5.127.1.26581
+2:
+  name: Kitchen
+  uuid: 00:91:82:73:00:b9:c3:7a-0b
+  type: Extended color light
+  firmware: 5.127.1.26581
+            </code></pre>
+    </article>
+    <article>
+        <a href="#cli-lights-control" name="cli-lights-control">
+            <h2>Control Lights</h2>
+        </a>
+        <p>
+            You can control lights using the <code>lights:control</code>
+            command, including on/off, brightness, and color.
+        </p>
+        <pre><code class="shell">
+$ shade lights:control 1 --on --brightness 50
+            </code></pre>
+    </article>
+    <article>
+        <a href="#cli-more" name="cli-more">
+            <h2>Groups, Scenes, and more</h2>
+        </a>
+        <p>
+            Shade supports commands for many of Hue's API's like Groups and
+            Scenes. For a full list of commands, run
+            <code>shade-cli --help</code>
+        </p>
+    </article>
+</section>
+<section>
+    <header>
+        <a name="contributions" href="#contributions">
+            <h1>Contributions and Issues</h1>
+        </a>
+    </header>
+    <p>
+        Shade is free, <a href="https://github.com/InkApplications/Shade">Open Source</a>,
+        actively maintained, and always looking for contributions.
+    </p>
+    <p>
+        There are many Hue devices and things to do with them.<br />
+        Testing all that can be difficult.
+        If you have an issue, please
+        <a href="https://github.com/InkApplications/Shade/issues/new/choose">tell us</a>!
+    </p>
+</section>
+</body>
+</html>

--- a/docs/css/dark-1.1.css
+++ b/docs/css/dark-1.1.css
@@ -27,3 +27,7 @@ code,
 .only-dark {
     display: initial;
 }
+
+.hero > article {
+    background-color: #292929;
+}

--- a/docs/css/main-1.1.css
+++ b/docs/css/main-1.1.css
@@ -20,13 +20,6 @@ h3
     color: #616161;
 }
 
-section,
-body > header
-{
-    max-width: 1024px;
-    margin: 0 auto;
-}
-
 a,
 a:visited,
 a:hover
@@ -34,6 +27,18 @@ a:hover
     color: #212121;
     text-decoration: none;
     border-bottom: 1px solid #D84315;
+}
+a[href^="#"]
+{
+    border: none;
+}
+a[href^="#"]:hover
+{
+    cursor: default;
+}
+a[href^="#"]:focus
+{
+    outline: none;
 }
 
 h1 {
@@ -80,12 +85,71 @@ pre > code {
     margin: 1rem 0;
 }
 
+section,
+body > header
+{
+    max-width: 1024px;
+    margin: 0 auto;
+}
+
+body > header {
+    margin-bottom: 2rem;
+}
+
+body > header > a,
+body > header > a:hover
+{
+    border: none
+}
+
 .logo {
     height: 5rem;
     max-width: 40vw;
     margin: .5rem 0;
 }
 
+.hero {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: space-around;
+}
+.hero > h1 {
+    flex-basis: 70%;
+    align-self: center;
+    font-size: 2rem;
+}
+.hero > article {
+    border-radius: .5rem;
+    padding: 1rem;
+    flex-basis: 30%;
+    background-color: #f2f2f2f2;
+}
+.hero > article > h1 {
+    font-size: 2rem;
+}
+.hero > article > a {
+    border-bottom: none;
+    border: 1px solid #D84315;
+    padding: .5rem;
+    border-radius: .25rem;
+    margin: 1rem 0;
+    display: inline-block;
+    float: right;
+}
+.hero > nav {
+    flex-basis: 30%
+}
+.hero > nav > a {
+    border-bottom: none;
+    display: block;
+    padding: 1rem;
+    font-size: 1.25rem;
+}
+.hero > nav > a:after {
+    content: '⭢';
+    padding-left: .25rem;
+    padding-top: .125rem;
+}
 .links {
     margin: 1rem 0;
 }
@@ -113,4 +177,13 @@ pre > code {
 .hidden
 {
     display: none;
+}
+
+@media(max-width: 820px) {
+    .hero > h1,
+    .hero > nav,
+    .hero > article
+     {
+        flex-basis: 100%;
+    }
 }

--- a/docs/index.html
+++ b/docs/index.html
@@ -12,8 +12,8 @@
     <link href="https://fonts.googleapis.com/css?family=Alegreya+Sans+SC:300|Open+Sans:300|Inconsolata" rel="stylesheet">
     <link rel="stylesheet" href="css/atom-one-light.css" type="text/css" />
     <link rel="stylesheet" href="css/atom-one-dark.css" type="text/css" media="(prefers-color-scheme:dark)" />
-    <link rel="stylesheet" href="css/main-1.0.css" type="text/css" media="all" />
-    <link rel="stylesheet" href="css/dark-1.0.css" type="text/css" media="(prefers-color-scheme:dark)" />
+    <link rel="stylesheet" href="css/main-1.1.css" type="text/css" media="all" />
+    <link rel="stylesheet" href="css/dark-1.1.css" type="text/css" media="(prefers-color-scheme:dark)" />
 
     <script src="js/highlight.pack.js"></script>
     <script>hljs.initHighlightingOnLoad();</script>
@@ -23,67 +23,63 @@
         <img src="svg/logo-full-dark.svg" class="logo only-dark" alt="Shade Logo" />
         <img src="svg/logo-full.svg" class="logo only-light" alt="Shade Logo" />
     </header>
-    <section>
-        <p>Shade is a modern toolkit for the Philips Hue API for Kotlin and CLI tools.</p>
-        <ul class="links">
-            <li>
-                <a href="https://github.com/InkApplications/Shade/releases/latest">
-                    Latest Release
-                </a>
-            </li>
-            <li><a href="#sdk">Kotlin SDK</a></li>
-            <li><a href="https://github.com/InkApplications/Shade">GitHub</a></li>
-        </ul>
+    <section class="hero">
+        <h1>A modern toolkit for the Philips Hue API.</h1>
+        <nav>
+            <a href="https://github.com/InkApplications/Shade/releases/latest">Latest Release</a>
+            <a href="https://github.com/InkApplications/Shade">GitHub</a>
+        </nav>
+        <article>
+            <h1>Kotlin SDK</h1>
+            <p>Control your Hue devices with a rich Coroutine API.</p>
+            <a href="sdk-overview.html">Get Started</a>
+        </article>
+        <article>
+            <h1>CLI Tools</h1>
+            <p>Cross-platform command line application to control Hue devices.</p>
+            <a href="cli-overview.html">Get Started</a>
+        </article>
     </section>
     <section>
-        <header>
-            <a name="cli"></a>
-            <h1>CLI</h1>
-        </header>
-        <p>
-            Shade's CLI can provide an API for system tools to control lights,
-            can be run manually, and functions as a sample project for the SDK!
-        </p>
         <article>
-            <h2>Install</h2>
-            <h3>Using HomeBrew</h3>
+            <header>
+                <a name="straightforward-api"></a>
+                <h1>Straightforward API's</h1>
+            </header>
             <p>
-                If you're on a Mac with <a href="https://brew.sh">HomeBrew</a> you can
-                install Shade with the following command:
+                Shade provides API's that are intuitive, making it easy to get
+                started.
             </p>
-            <pre><code class="shell">
-$ brew install inkapplications/cli-tools/shade
-            </code></pre>
-            <h3>Manual Install</h3>
+
+<pre><code class="kotlin">
+suspend fun turnLightsOn() {
+    shade.groups.setState(
+        GROUP_ALL,
+        GroupStateModification(
+            on = on,
+            brightness = 50.percent,
+            colorTemperature = 5000.kelvin
+        )
+    )
+}
+
+</code></pre>
             <p>
-                For Windows or Linux, Shade's CLI can be installed by
-                downloading the
-                <a href="https://github.com/InkApplications/Shade/releases/latest">latest release</a>
-                and running the or <code>bin/shade.bat</code> or
-                <code>bin/shade</code> executable or adding them to your
-                <code>$PATH</code>.
+                Kotlin Coroutines makes controlling your Hue lights on the JVM
+                easy, while maintaining a well-structured asynchronous API.
             </p>
         </article>
         <article>
-            <h2>Connect to a Hue bridge</h2>
+            <header>
+                <a name="straightforward-api"></a>
+                <h1>Cross-Platform CLI</h1>
+            </header>
             <p>
-                You can set up your connection to Hue using the
-                <code>connect</code> command. This will automatically discover
-                hue bridges on the network and attempt to authenticate with
-                them.
+                Shade's command line tools run on Mac, Windows or Linux. Built
+                on Shade's SDK, the CLI provides an easy way to control
+                lights in any terminal or script.
             </p>
-            <pre><code class="shell">
-$ shade connect
-Connecting to bridge at 192.168.1.100
-Waiting to connect. Press the button on your Hue Device now.
-            </code></pre>
-        </article>
-        <article>
-            <h2>List lights</h2>
-            <p>
-                You can get information about of all the lights known to your
-                Hue bridge with the <code>lights:list</code> command.
-            </p>
+
             <pre><code class="shell">
 $ shade lights:list
 1:
@@ -96,237 +92,27 @@ $ shade lights:list
   uuid: 00:91:82:73:00:b9:c3:7a-0b
   type: Extended color light
   firmware: 5.127.1.26581
-            </code></pre>
-        </article>
-        <article>
-            <h2>Control Lights</h2>
-            <p>
-                You can control lights using the <code>lights:control</code>
-                command, including on/off, brightness, and color.
-            </p>
-            <pre><code class="shell">
+
 $ shade lights:control 1 --on --brightness 50
-            </code></pre>
+
+</code></pre>
         </article>
         <article>
-            <h2>Groups, Scenes, and more</h2>
+            <header>
+                <a name="straightforward-api"></a>
+                <h1>Free and Stable</h1>
+            </header>
             <p>
-                Shade supports commands for many of Hue's API's like Groups and
-                Scenes. For a full list of commands, run
-                <code>shade-cli --help</code>
+                Shade is free, <a href="https://github.com/InkApplications/Shade">Open Source</a>,
+                actively maintained, and always looking for contributions.
+            </p>
+            <p>
+                There are many Hue devices and things to do with them.<br />
+                Testing all that can be difficult.
+                If you have an issue, please
+                <a href="https://github.com/InkApplications/Shade/issues/new/choose">tell us</a>!
             </p>
         </article>
-    </section>
-    <section>
-        <header>
-            <a name="sdk"></a>
-            <h1>Kotlin SDK</h1>
-        </header>
-        <p>
-            Shade's Kotlin SDK provides simple type-safe access to your Hue
-            lights. Shade is built using Kotlin's Coroutines to provide a simple
-            straightforward API on Android or the JVM.
-        </p>
-        <a name="sdk-intro"></a>
-        <h2>Introduction</h2>
-        <p>
-            Shade can be used to connect and manipulate lights in Hue:
-        </p>
-        <pre><code class="kotlin">
-fun main() {
-    runBlocking {
-        println("Searching for Hue Bridges")
-        val shade = Shade()
-        val devices = shade.discovery.getDevices()
-        shade.setBaseUrl(devices.first().url)
-
-        println("Press the connect button on the hue bridge")
-        shade.auth.awaitToken()
-
-        println("Turning all the lights on!")
-        shade.groups.setState(
-            GROUP_ALL,
-            GroupStateModification(
-                on = on
-            )
-        )
-    }
-}
-        </code></pre>
-        <p>
-            Shade's Kotlin SDK currently supports controlling Lights, Groups,
-            Scenes and Schedules. With plans to support new API's as Hue
-            introduces them.
-        </p>
-        <h3>Modern Kotlin API</h3>
-        <p>
-            Shade is designed for Kotlin's suspending Coroutines and uses many
-            of Kotlin's modern types. While it's possible to convert these for
-            use with other frameworks or for use with Java, it is not officially
-            supported.
-        </p>
-
-        <article>
-            <a name="sdk-install"></a>
-            <h2>Installation</h2>
-            <p>
-                If you haven’t already, add JitPack to your gradle repositories in your build.gradle file:
-            </p>
-            <pre><code>
-repositories {
-    maven {
-        url "https://jitpack.io"
-    }
-}
-            </code></pre>
-            <p>
-                Next, add Shade as a dependency to your build.gradle file:
-            </p>
-            <pre><code>
-compile "com.github.Inkapplications.Shade:shade:+" // Replace with exact version
-            </code></pre>
-        </article>
-        <article>
-            <a name="sdk-discover"></a>
-            <h2>Discover a Hue Bridge</h2>
-            <p>
-                Before you can start discovering, you need to create an
-                uninitialized Shade instance. Just call the constructor to do
-                this:
-            </p>
-
-            <pre><code class="kotlin">
-val shade = Shade()
-            </code></pre>
-
-            <p>
-                If you know the URL/IP of the Bridge you want to connect to,
-                you can specify it with the <code>initBaseUrl</code> parameter
-                in the constructor, and skip right to controlling your lights!
-            </p>
-
-            <p>
-                Shade is broken into several modules. To find a Hue Bridge to
-                connect to, you'll use the <code>discovery</code> module. Which
-                provides a <code>getDevices()</code> method.
-            </p>
-
-            <p>
-                Because multiple Hue Bridges may be on the network, discovery
-                returns a list of devices. Each device has an ID and an
-                IP address.
-            </p>
-
-            <pre><code class="kotlin">
-shade.discovery.getDevices().forEach {
-    println("found device: ${it.id} ip: ${it.ip}")
-}
-            </code></pre>
-
-            <p>
-                Once you select a device to use, you can tell Shade to connect
-                to it using the <code>setBaseUrl</code> method. This can be
-                called at any point to change the bridge this instance of
-                Shade is connected to.
-            </p>
-
-            <pre><code class="kotlin">
-shade.setBaseUrl(device.url)
-            </code></pre>
-
-            <h3>Authenticate</h3>
-            <p>
-                The last step you need to do before you can start controlling
-                lights is to request access. Hue does this by tapping the button
-                on the top of the hub. To start this process use the
-                <code>awaitToken</code> method in <code>auth</code> module.
-            </p>
-            <pre><code class="kotlin">
-shade.auth.awaitToken()
-            </code></pre>
-            <p>
-                This method will eventually timeout after an amount of time.
-                You can change how many retries and how often the SDK will poll
-                the bridge for auth using the optional <code>retries</code>
-                and <code>timeout</code> arguments on the
-                <code>awaitToken()</code> method.
-            </p>
-        </article>
-        <article>
-            <a name="sdk-lights"></a>
-            <h2>Light Controls</h2>
-            <p>
-                Controlling individual lights is done through the
-                <code>lights</code> module.
-            </p>
-            <h3>Get a List of Lights</h3>
-            <p>
-                You can get a list of lights using <code>getLights()</code>
-            </p>
-            <pre><code class="kotlin">
-shade.lights.getLights().forEach { (id, light) ->
-    println("Found light $id named ${light.name}")
-}
-            </code></pre>
-            <h3>Change Light State</h3>
-            <p>
-                To turn lights on/off, change their color or brightness you
-                can use the <code>setState</code> method with a
-                <code>LightStateModification</code> object.
-            </p>
-            <p>
-                The <code>LightStateModification</code> object is used to
-                describe properties that will be changed on the light. If a
-                property is left <code>null</code> / not specified, the current
-                state of the light will not change.
-            </p>
-            <pre><code class="kotlin">
-shade.lights.setState(id, LightStateModification(on = true, brightness = 50.percent))
-            </code></pre>
-        </article>
-        <article>
-            <a name="sdk-groups"></a>
-            <h2>Group Controls</h2>
-            <p>
-                Groups can be accessed through the <code>groups</code> module
-                and function very similar to individual lights.
-            </p>
-            <h3>Get a List of Groups</h3>
-            <p>
-                You can get a list of groups using <code>getGroups()</code>
-            </p>
-            <pre><code class="kotlin">
-shade.groups.getGroups().forEach { (id, light) ->
-    println("Found Group $id named ${light.name}")
-}
-            </code></pre>
-            <h3>Change a Group of Lights</h3>
-            <p>
-                Changing a group of lights is similar to changing a light state
-                except is done with a <code>GroupStateModification</code>
-                object. Like light modifications, properties that are not set
-                on the modification object will retain its current state.
-            </p>
-            <pre><code class="kotlin">
-shade.groups.setState(id, GroupStateModification(on = true, colorTemperature = 5000.kelvin))
-            </code></pre>
-        </article>
-    </section>
-    <section>
-        <header>
-            <a name="contributions"></a>
-            <h1>Contributions and Issues</h1>
-        </header>
-        <p>
-            Shade is free, <a href="https://github.com/InkApplications/Shade">Open Source</a>,
-            actively maintained, and always looking for contributions.
-        </p>
-        <p>
-            There are many Hue devices and things to do with them.<br />
-            Testing all that can be difficult.
-            If you have an issue, please
-            <a href="https://github.com/InkApplications/Shade/issues/new">tell us</a>!
-        </p>
     </section>
 </body>
 </html>

--- a/docs/sdk-overview.html
+++ b/docs/sdk-overview.html
@@ -1,0 +1,240 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8" />
+    <meta name="keywords" content="Shade, Hue, Kotlin, Java, Android, Library" />
+    <meta name="robots" content="index, follow" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+    <title>Kotlin SDK / Shade</title>
+
+    <link rel="stylesheet" href="css/reset.css" type="text/css" media="all" />
+    <link href="https://fonts.googleapis.com/css?family=Alegreya+Sans+SC:300|Open+Sans:300|Inconsolata" rel="stylesheet">
+    <link rel="stylesheet" href="css/atom-one-light.css" type="text/css" />
+    <link rel="stylesheet" href="css/atom-one-dark.css" type="text/css" media="(prefers-color-scheme:dark)" />
+    <link rel="stylesheet" href="css/main-1.1.css" type="text/css" media="all" />
+    <link rel="stylesheet" href="css/dark-1.1.css" type="text/css" media="(prefers-color-scheme:dark)" />
+
+    <script src="js/highlight.pack.js"></script>
+    <script>hljs.initHighlightingOnLoad();</script>
+</head>
+<body>
+<header>
+    <a href="index.html">
+        <img src="svg/logo-full-dark.svg" class="logo only-dark" alt="Shade Logo" />
+        <img src="svg/logo-full.svg" class="logo only-light" alt="Shade Logo" />
+    </a>
+</header>
+<section>
+    <header>
+        <a name="sdk" href="#sdk">
+            <h1>Kotlin SDK</h1>
+        </a>
+    </header>
+    <p>
+        Shade's Kotlin SDK provides simple type-safe access to your Hue
+        lights. Shade is built using Kotlin's Coroutines to provide a simple
+        straightforward API on Android or the JVM.
+    </p>
+    <a name="sdk-intro" href="#sdk-intro">
+        <h2>Introduction</h2>
+    </a>
+    <p>
+        Shade can be used to connect and manipulate lights in Hue:
+    </p>
+    <pre><code class="kotlin">
+fun main() {
+    runBlocking {
+        println("Searching for Hue Bridges")
+        val shade = Shade()
+        val devices = shade.discovery.getDevices()
+        shade.setBaseUrl(devices.first().url)
+
+        println("Press the connect button on the hue bridge")
+        shade.auth.awaitToken()
+
+        println("Turning all the lights on!")
+        shade.groups.setState(
+            GROUP_ALL,
+            GroupStateModification(
+                on = on
+            )
+        )
+    }
+}
+        </code></pre>
+    <p>
+        Shade's Kotlin SDK currently supports controlling Lights, Groups,
+        Scenes and Schedules. With plans to support new API's as Hue
+        introduces them.
+    </p>
+
+    <article>
+        <a name="sdk-install" href="#sdk-install">
+            <h2>Installation</h2>
+        </a>
+        <p>
+            If you haven’t already, add JitPack to your gradle repositories in your build.gradle file:
+        </p>
+        <pre><code>
+repositories {
+    maven {
+        url "https://jitpack.io"
+    }
+}
+            </code></pre>
+        <p>
+            Next, add Shade as a dependency to your build.gradle file:
+        </p>
+        <pre><code>
+compile "com.github.Inkapplications.Shade:shade:+" // Replace with exact version
+            </code></pre>
+    </article>
+    <article>
+        <a name="sdk-discover" href="#sdk-discover">
+            <h2>Discover a Hue Bridge</h2>
+        </a>
+        <p>
+            Before you can start discovering, you need to create an
+            uninitialized Shade instance. Just call the constructor to do
+            this:
+        </p>
+
+        <pre><code class="kotlin">
+val shade = Shade()
+            </code></pre>
+
+        <p>
+            If you know the URL/IP of the Bridge you want to connect to,
+            you can specify it with the <code>initBaseUrl</code> parameter
+            in the constructor, and skip right to controlling your lights!
+        </p>
+
+        <p>
+            Shade is broken into several modules. To find a Hue Bridge to
+            connect to, you'll use the <code>discovery</code> module. Which
+            provides a <code>getDevices()</code> method.
+        </p>
+
+        <p>
+            Because multiple Hue Bridges may be on the network, discovery
+            returns a list of devices. Each device has an ID and an
+            IP address.
+        </p>
+
+        <pre><code class="kotlin">
+shade.discovery.getDevices().forEach {
+    println("found device: ${it.id} ip: ${it.ip}")
+}
+            </code></pre>
+
+        <p>
+            Once you select a device to use, you can tell Shade to connect
+            to it using the <code>setBaseUrl</code> method. This can be
+            called at any point to change the bridge this instance of
+            Shade is connected to.
+        </p>
+
+        <pre><code class="kotlin">
+shade.setBaseUrl(device.url)
+            </code></pre>
+
+        <h3>Authenticate</h3>
+        <p>
+            The last step you need to do before you can start controlling
+            lights is to request access. Hue does this by tapping the button
+            on the top of the hub. To start this process use the
+            <code>awaitToken</code> method in <code>auth</code> module.
+        </p>
+        <pre><code class="kotlin">
+shade.auth.awaitToken()
+            </code></pre>
+        <p>
+            This method will eventually timeout after an amount of time.
+            You can change how many retries and how often the SDK will poll
+            the bridge for auth using the optional <code>retries</code>
+            and <code>timeout</code> arguments on the
+            <code>awaitToken()</code> method.
+        </p>
+    </article>
+    <article>
+        <a name="sdk-lights" href="#sdk-lights">
+            <h2>Light Controls</h2>
+        </a>
+        <p>
+            Controlling individual lights is done through the
+            <code>lights</code> module.
+        </p>
+        <h3>Get a List of Lights</h3>
+        <p>
+            You can get a list of lights using <code>getLights()</code>
+        </p>
+        <pre><code class="kotlin">
+shade.lights.getLights().forEach { (id, light) ->
+    println("Found light $id named ${light.name}")
+}
+            </code></pre>
+        <h3>Change Light State</h3>
+        <p>
+            To turn lights on/off, change their color or brightness you
+            can use the <code>setState</code> method with a
+            <code>LightStateModification</code> object.
+        </p>
+        <p>
+            The <code>LightStateModification</code> object is used to
+            describe properties that will be changed on the light. If a
+            property is left <code>null</code> / not specified, the current
+            state of the light will not change.
+        </p>
+        <pre><code class="kotlin">
+shade.lights.setState(id, LightStateModification(on = true, brightness = 50.percent))
+            </code></pre>
+    </article>
+    <article>
+        <a name="sdk-groups" href="#sdk-groups">
+            <h2>Group Controls</h2>
+        </a>
+        <p>
+            Groups can be accessed through the <code>groups</code> module
+            and function very similar to individual lights.
+        </p>
+        <h3>Get a List of Groups</h3>
+        <p>
+            You can get a list of groups using <code>getGroups()</code>
+        </p>
+        <pre><code class="kotlin">
+shade.groups.getGroups().forEach { (id, light) ->
+    println("Found Group $id named ${light.name}")
+}
+            </code></pre>
+        <h3>Change a Group of Lights</h3>
+        <p>
+            Changing a group of lights is similar to changing a light state
+            except is done with a <code>GroupStateModification</code>
+            object. Like light modifications, properties that are not set
+            on the modification object will retain its current state.
+        </p>
+        <pre><code class="kotlin">
+shade.groups.setState(id, GroupStateModification(on = true, colorTemperature = 5000.kelvin))
+            </code></pre>
+    </article>
+</section>
+<section>
+    <header>
+        <a name="contributions" href="#contributions">
+            <h1>Contributions and Issues</h1>
+        </a>
+    </header>
+    <p>
+        Shade is free, <a href="https://github.com/InkApplications/Shade">Open Source</a>,
+        actively maintained, and always looking for contributions.
+    </p>
+    <p>
+        There are many Hue devices and things to do with them.<br />
+        Testing all that can be difficult.
+        If you have an issue, please
+        <a href="https://github.com/InkApplications/Shade/issues/new/choose">tell us</a>!
+    </p>
+</section>
+</body>
+</html>


### PR DESCRIPTION
Creates a cleaner looking landing page for the website and breaks apart the SDK and CLI introductions.