### PR TITLE
Deprecate value class values/valueOf methods

### DIFF
--- a/devices/api/devices.api
+++ b/devices/api/devices.api
@@ -111,6 +111,7 @@ public final class inkapplications/shade/devices/structures/ModelId$Companion {
 public final class inkapplications/shade/devices/structures/ProductArchetype {
 	public static final field Companion Linkapplications/shade/devices/structures/ProductArchetype$Companion;
 	public static final synthetic fun box-impl (Ljava/lang/String;)Linkapplications/shade/devices/structures/ProductArchetype;
+	public static fun constructor-impl (Ljava/lang/String;)Ljava/lang/String;
 	public fun equals (Ljava/lang/Object;)Z
 	public static fun equals-impl (Ljava/lang/String;Ljava/lang/Object;)Z
 	public static final fun equals-impl0 (Ljava/lang/String;Ljava/lang/String;)Z

--- a/devices/src/commonMain/kotlin/inkapplications/shade/devices/structures/ProductArchetype.kt
+++ b/devices/src/commonMain/kotlin/inkapplications/shade/devices/structures/ProductArchetype.kt
@@ -8,7 +8,7 @@ import kotlin.jvm.JvmInline
  */
 @Serializable
 @JvmInline
-value class ProductArchetype private constructor(val key: String) {
+value class ProductArchetype(val key: String) {
     override fun toString(): String = key
 
     companion object {

--- a/lights/api/lights.api
+++ b/lights/api/lights.api
@@ -272,6 +272,7 @@ public final class inkapplications/shade/lights/parameters/ColorTemperatureParam
 public final class inkapplications/shade/lights/parameters/DeltaAction {
 	public static final field Companion Linkapplications/shade/lights/parameters/DeltaAction$Companion;
 	public static final synthetic fun box-impl (Ljava/lang/String;)Linkapplications/shade/lights/parameters/DeltaAction;
+	public static fun constructor-impl (Ljava/lang/String;)Ljava/lang/String;
 	public fun equals (Ljava/lang/Object;)Z
 	public static fun equals-impl (Ljava/lang/String;Ljava/lang/Object;)Z
 	public static final fun equals-impl0 (Ljava/lang/String;Ljava/lang/String;)Z
@@ -549,6 +550,7 @@ public final class inkapplications/shade/lights/parameters/TimedEffectsParameter
 public final class inkapplications/shade/lights/structures/AlertEffectType {
 	public static final field Companion Linkapplications/shade/lights/structures/AlertEffectType$Companion;
 	public static final synthetic fun box-impl (Ljava/lang/String;)Linkapplications/shade/lights/structures/AlertEffectType;
+	public static fun constructor-impl (Ljava/lang/String;)Ljava/lang/String;
 	public fun equals (Ljava/lang/Object;)Z
 	public static fun equals-impl (Ljava/lang/String;Ljava/lang/Object;)Z
 	public static final fun equals-impl0 (Ljava/lang/String;Ljava/lang/String;)Z
@@ -820,6 +822,7 @@ public final class inkapplications/shade/lights/structures/DimmingValue$Companio
 public final class inkapplications/shade/lights/structures/DynamicsStatus {
 	public static final field Companion Linkapplications/shade/lights/structures/DynamicsStatus$Companion;
 	public static final synthetic fun box-impl (Ljava/lang/String;)Linkapplications/shade/lights/structures/DynamicsStatus;
+	public static fun constructor-impl (Ljava/lang/String;)Ljava/lang/String;
 	public fun equals (Ljava/lang/Object;)Z
 	public static fun equals-impl (Ljava/lang/String;Ljava/lang/Object;)Z
 	public static final fun equals-impl0 (Ljava/lang/String;Ljava/lang/String;)Z
@@ -889,6 +892,7 @@ public final class inkapplications/shade/lights/structures/Gamut$Companion {
 public final class inkapplications/shade/lights/structures/GamutType {
 	public static final field Companion Linkapplications/shade/lights/structures/GamutType$Companion;
 	public static final synthetic fun box-impl (Ljava/lang/String;)Linkapplications/shade/lights/structures/GamutType;
+	public static fun constructor-impl (Ljava/lang/String;)Ljava/lang/String;
 	public fun equals (Ljava/lang/Object;)Z
 	public static fun equals-impl (Ljava/lang/String;Ljava/lang/Object;)Z
 	public static final fun equals-impl0 (Ljava/lang/String;Ljava/lang/String;)Z
@@ -1082,6 +1086,7 @@ public final class inkapplications/shade/lights/structures/LightDynamics$Compani
 public final class inkapplications/shade/lights/structures/LightEffect {
 	public static final field Companion Linkapplications/shade/lights/structures/LightEffect$Companion;
 	public static final synthetic fun box-impl (Ljava/lang/String;)Linkapplications/shade/lights/structures/LightEffect;
+	public static fun constructor-impl (Ljava/lang/String;)Ljava/lang/String;
 	public fun equals (Ljava/lang/Object;)Z
 	public static fun equals-impl (Ljava/lang/String;Ljava/lang/Object;)Z
 	public static final fun equals-impl0 (Ljava/lang/String;Ljava/lang/String;)Z
@@ -1117,6 +1122,7 @@ public final class inkapplications/shade/lights/structures/LightEffect$Companion
 public final class inkapplications/shade/lights/structures/LightMode {
 	public static final field Companion Linkapplications/shade/lights/structures/LightMode$Companion;
 	public static final synthetic fun box-impl (Ljava/lang/String;)Linkapplications/shade/lights/structures/LightMode;
+	public static fun constructor-impl (Ljava/lang/String;)Ljava/lang/String;
 	public fun equals (Ljava/lang/Object;)Z
 	public static fun equals-impl (Ljava/lang/String;Ljava/lang/Object;)Z
 	public static final fun equals-impl0 (Ljava/lang/String;Ljava/lang/String;)Z
@@ -1218,6 +1224,7 @@ public final class inkapplications/shade/lights/structures/LightPowerup$Safety :
 public final class inkapplications/shade/lights/structures/LightSignal {
 	public static final field Companion Linkapplications/shade/lights/structures/LightSignal$Companion;
 	public static final synthetic fun box-impl (Ljava/lang/String;)Linkapplications/shade/lights/structures/LightSignal;
+	public static fun constructor-impl (Ljava/lang/String;)Ljava/lang/String;
 	public fun equals (Ljava/lang/Object;)Z
 	public static fun equals-impl (Ljava/lang/String;Ljava/lang/Object;)Z
 	public static final fun equals-impl0 (Ljava/lang/String;Ljava/lang/String;)Z
@@ -1460,6 +1467,7 @@ public final class inkapplications/shade/lights/structures/StandardTemperatures 
 public final class inkapplications/shade/lights/structures/TimedLightEffect {
 	public static final field Companion Linkapplications/shade/lights/structures/TimedLightEffect$Companion;
 	public static final synthetic fun box-impl (Ljava/lang/String;)Linkapplications/shade/lights/structures/TimedLightEffect;
+	public static fun constructor-impl (Ljava/lang/String;)Ljava/lang/String;
 	public fun equals (Ljava/lang/Object;)Z
 	public static fun equals-impl (Ljava/lang/String;Ljava/lang/Object;)Z
 	public static final fun equals-impl0 (Ljava/lang/String;Ljava/lang/String;)Z

--- a/lights/src/commonMain/kotlin/inkapplications/shade/lights/parameters/DeltaAction.kt
+++ b/lights/src/commonMain/kotlin/inkapplications/shade/lights/parameters/DeltaAction.kt
@@ -8,7 +8,7 @@ import kotlin.jvm.JvmInline
  */
 @JvmInline
 @Serializable
-value class DeltaAction private constructor(val key: String) {
+value class DeltaAction(val key: String) {
     override fun toString(): String = key
 
     companion object {
@@ -16,7 +16,13 @@ value class DeltaAction private constructor(val key: String) {
         val Down = DeltaAction("down")
         val Stop = DeltaAction("stop")
 
+        @Deprecated("This is an unbounded set of values. The values provided here are not exhaustive and will be removed in a future release.")
         fun values(): Array<DeltaAction> = arrayOf(Up, Down, Stop)
+
+        @Deprecated(
+            message = "Deprecated in favor of constructor",
+            replaceWith = ReplaceWith("DeltaAction(key)"),
+        )
         fun valueOf(key: String) = values().single { it.key == key }
     }
 }

--- a/lights/src/commonMain/kotlin/inkapplications/shade/lights/structures/AlertEffectType.kt
+++ b/lights/src/commonMain/kotlin/inkapplications/shade/lights/structures/AlertEffectType.kt
@@ -8,12 +8,19 @@ import kotlin.jvm.JvmInline
  */
 @JvmInline
 @Serializable
-value class AlertEffectType private constructor(val key: String) {
+value class AlertEffectType(val key: String) {
     override fun toString(): String = key
 
     companion object {
         val Breathe = AlertEffectType("breathe")
+
+        @Deprecated("This is an unbounded set of values. The values provided here are not exhaustive and will be removed in a future release.")
         fun values(): Array<AlertEffectType> = arrayOf(Breathe)
+
+        @Deprecated(
+            message = "Deprecated in favor of constructor",
+            replaceWith = ReplaceWith("AlertEffectType(key)"),
+        )
         fun valueOf(key: String) = values().single { it.key == key }
     }
 }

--- a/lights/src/commonMain/kotlin/inkapplications/shade/lights/structures/DynamicsStatus.kt
+++ b/lights/src/commonMain/kotlin/inkapplications/shade/lights/structures/DynamicsStatus.kt
@@ -8,13 +8,20 @@ import kotlin.jvm.JvmInline
  */
 @JvmInline
 @Serializable
-value class DynamicsStatus private constructor(val key: String) {
+value class DynamicsStatus(val key: String) {
     override fun toString(): String = key
 
     companion object {
         val DynamicPalette = DynamicsStatus("dynamic_palette")
         val None = DynamicsStatus("none")
+
+        @Deprecated("This is an unbounded set of values. The values provided here are not exhaustive and will be removed in a future release.")
         fun values(): Array<DynamicsStatus> = arrayOf(None, DynamicPalette)
+
+        @Deprecated(
+            message = "Deprecated in favor of constructor",
+            replaceWith = ReplaceWith("DynamicsStatus(key)"),
+        )
         fun valueOf(key: String) = values().single { it.key == key }
     }
 }

--- a/lights/src/commonMain/kotlin/inkapplications/shade/lights/structures/GamutType.kt
+++ b/lights/src/commonMain/kotlin/inkapplications/shade/lights/structures/GamutType.kt
@@ -8,7 +8,7 @@ import kotlin.jvm.JvmInline
  */
 @Serializable
 @JvmInline
-value class GamutType private constructor(val key: String) {
+value class GamutType(val key: String) {
     override fun toString(): String = key
 
     companion object {
@@ -32,7 +32,13 @@ value class GamutType private constructor(val key: String) {
          */
         val Other = GamutType("other")
 
+        @Deprecated("This is an unbounded set of values. The values provided here are not exhaustive and will be removed in a future release.")
         fun values(): Array<GamutType> = arrayOf(A, B, C, Other)
+
+        @Deprecated(
+            message = "Deprecated in favor of constructor",
+            replaceWith = ReplaceWith("GamutType(key)"),
+        )
         fun valueOf(key: String) = values().single { it.key == key }
     }
 }

--- a/lights/src/commonMain/kotlin/inkapplications/shade/lights/structures/LightEffect.kt
+++ b/lights/src/commonMain/kotlin/inkapplications/shade/lights/structures/LightEffect.kt
@@ -8,7 +8,7 @@ import kotlin.jvm.JvmInline
  */
 @JvmInline
 @Serializable
-value class LightEffect private constructor(val key: String) {
+value class LightEffect(val key: String) {
     override fun toString(): String = key
 
     companion object {
@@ -16,7 +16,13 @@ value class LightEffect private constructor(val key: String) {
         val Candle = LightEffect("candle")
         val None = LightEffect("no_effect")
 
+        @Deprecated("This is an unbounded set of values. The values provided here are not exhaustive and will be removed in a future release.")
         fun values(): Array<LightEffect> = arrayOf(Fire, Candle, None)
+
+        @Deprecated(
+            message = "Deprecated in favor of constructor",
+            replaceWith = ReplaceWith("LightEffect(key)"),
+        )
         fun valueOf(key: String) = values().single { it.key == key }
     }
 }

--- a/lights/src/commonMain/kotlin/inkapplications/shade/lights/structures/LightMode.kt
+++ b/lights/src/commonMain/kotlin/inkapplications/shade/lights/structures/LightMode.kt
@@ -8,14 +8,20 @@ import kotlin.jvm.JvmInline
  */
 @JvmInline
 @Serializable
-value class LightMode private constructor(val key: String) {
+value class LightMode(val key: String) {
     override fun toString(): String = key
 
     companion object {
         val Normal = LightMode("normal")
         val Streaming = LightMode("streaming")
 
+        @Deprecated("This is an unbounded set of values. The values provided here are not exhaustive and will be removed in a future release.")
         fun values(): Array<LightMode> = arrayOf(Normal, Streaming)
+
+        @Deprecated(
+            message = "Deprecated in favor of constructor",
+            replaceWith = ReplaceWith("LightMode(key)"),
+        )
         fun valueOf(key: String) = values().single { it.key == key }
     }
 }

--- a/lights/src/commonMain/kotlin/inkapplications/shade/lights/structures/LightSignal.kt
+++ b/lights/src/commonMain/kotlin/inkapplications/shade/lights/structures/LightSignal.kt
@@ -8,14 +8,20 @@ import kotlin.jvm.JvmInline
  */
 @Serializable
 @JvmInline
-value class LightSignal private constructor(val key: String) {
+value class LightSignal(val key: String) {
     override fun toString(): String = key
 
     companion object {
         val NoSignal = LightSignal("no_signal")
         val OnOff = LightSignal("on_off")
 
+        @Deprecated("This is an unbounded set of values. The values provided here are not exhaustive and will be removed in a future release.")
         fun values(): Array<LightSignal> = arrayOf(NoSignal, OnOff)
+
+        @Deprecated(
+            message = "Deprecated in favor of constructor",
+            replaceWith = ReplaceWith("LightSignal(key)"),
+        )
         fun valueOf(key: String) = values().single { it.key == key }
     }
 }

--- a/lights/src/commonMain/kotlin/inkapplications/shade/lights/structures/TimedLightEffect.kt
+++ b/lights/src/commonMain/kotlin/inkapplications/shade/lights/structures/TimedLightEffect.kt
@@ -8,14 +8,20 @@ import kotlin.jvm.JvmInline
  */
 @JvmInline
 @Serializable
-value class TimedLightEffect private constructor(val key: String) {
+value class TimedLightEffect(val key: String) {
     override fun toString(): String = key
 
     companion object {
         val Sunrise = TimedLightEffect("sunrise")
         val None = TimedLightEffect("no_effect")
 
+        @Deprecated("This is an unbounded set of values. The values provided here are not exhaustive and will be removed in a future release.")
         fun values(): Array<TimedLightEffect> = arrayOf(Sunrise, None)
+
+        @Deprecated(
+            message = "Deprecated in favor of constructor",
+            replaceWith = ReplaceWith("TimedLightEffect(key)"),
+        )
         fun valueOf(key: String) = values().single { it.key == key }
     }
 }

--- a/structures/api/structures.api
+++ b/structures/api/structures.api
@@ -219,6 +219,7 @@ public final class inkapplications/shade/structures/ResourceReference$Companion 
 public final class inkapplications/shade/structures/ResourceType {
 	public static final field Companion Linkapplications/shade/structures/ResourceType$Companion;
 	public static final synthetic fun box-impl (Ljava/lang/String;)Linkapplications/shade/structures/ResourceType;
+	public static fun constructor-impl (Ljava/lang/String;)Ljava/lang/String;
 	public fun equals (Ljava/lang/Object;)Z
 	public static fun equals-impl (Ljava/lang/String;Ljava/lang/Object;)Z
 	public static final fun equals-impl0 (Ljava/lang/String;Ljava/lang/String;)Z
@@ -300,6 +301,7 @@ public final class inkapplications/shade/structures/SecurityStrategy$PlatformTru
 public final class inkapplications/shade/structures/SegmentArchetype {
 	public static final field Companion Linkapplications/shade/structures/SegmentArchetype$Companion;
 	public static final synthetic fun box-impl (Ljava/lang/String;)Linkapplications/shade/structures/SegmentArchetype;
+	public static fun constructor-impl (Ljava/lang/String;)Ljava/lang/String;
 	public fun equals (Ljava/lang/Object;)Z
 	public static fun equals-impl (Ljava/lang/String;Ljava/lang/Object;)Z
 	public static final fun equals-impl0 (Ljava/lang/String;Ljava/lang/String;)Z

--- a/structures/src/commonMain/kotlin/inkapplications/shade/structures/ResourceType.kt
+++ b/structures/src/commonMain/kotlin/inkapplications/shade/structures/ResourceType.kt
@@ -8,7 +8,7 @@ import kotlin.jvm.JvmInline
  */
 @Serializable
 @JvmInline
-value class ResourceType private constructor(val key: String) {
+value class ResourceType(val key: String) {
     override fun toString(): String = key
 
     companion object {
@@ -39,7 +39,7 @@ value class ResourceType private constructor(val key: String) {
         val GeofenceClient = ResourceType("geofence_client")
         val Geolocation = ResourceType("geolocation")
 
-
+        @Deprecated("This is an unbounded set of values. The values provided here are not exhaustive and will be removed in a future release.")
         fun values(): Array<ResourceType> = arrayOf(
             Device,
             BridgeHome,
@@ -67,6 +67,11 @@ value class ResourceType private constructor(val key: String) {
             Geofence,
             GeofenceClient,
             Geolocation,
+        )
+
+        @Deprecated(
+            message = "Deprecated in favor of constructor",
+            replaceWith = ReplaceWith("ResourceType(key)"),
         )
         fun valueOf(key: String) = values().single { it.key == key }
     }

--- a/structures/src/commonMain/kotlin/inkapplications/shade/structures/SegmentArchetype.kt
+++ b/structures/src/commonMain/kotlin/inkapplications/shade/structures/SegmentArchetype.kt
@@ -8,7 +8,7 @@ import kotlin.jvm.JvmInline
  */
 @JvmInline
 @Serializable
-value class SegmentArchetype private constructor(val key: String) {
+value class SegmentArchetype(val key: String) {
     override fun toString(): String = key
 
     companion object {
@@ -53,6 +53,7 @@ value class SegmentArchetype private constructor(val key: String) {
         val Pool = SegmentArchetype("pool")
         val Other = SegmentArchetype("other")
 
+        @Deprecated("This is an unbounded set of values. The values provided here are not exhaustive and will be removed in a future release.")
         fun values(): Array<SegmentArchetype> = arrayOf(
             LivingRoom,
             Kitchen,
@@ -94,6 +95,11 @@ value class SegmentArchetype private constructor(val key: String) {
             Barbecue,
             Pool,
             Other,
+        )
+
+        @Deprecated(
+            message = "Deprecated in favor of constructor.",
+            replaceWith = ReplaceWith("SegmentArchetype(key)"),
         )
         fun valueOf(key: String) = values().single { it.key == key }
     }


### PR DESCRIPTION
These value classes should be unbounded, so by definition they aren't constrained to the values in these methods, so they should be removed